### PR TITLE
improve zsh aliases

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -1,4 +1,4 @@
-alias ls="ls --color=auto"
+alias ls="ls -a --color=auto"
 alias grep="grep --color=auto"
 
 alias vim="nvim"


### PR DESCRIPTION
To improve the visibility of hidden files like `.env`, which developers often need, I propose to alias the `ls` command to `ls -a --color=auto`.